### PR TITLE
Limit the number of concurrent list nodes processed

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -312,11 +312,14 @@ func (r *Request) execList(ctx context.Context, sels []selected.Selection, typ *
 	l := resolver.Len()
 	entryouts := make([]bytes.Buffer, l)
 
+	sem := make(chan struct{}, cap(r.Limiter))
 	if selected.HasAsyncSel(sels) {
 		var wg sync.WaitGroup
 		wg.Add(l)
 		for i := 0; i < l; i++ {
+			sem <- struct{}{}
 			go func(i int) {
+				defer func() { <-sem }()
 				defer wg.Done()
 				defer r.handlePanic(ctx)
 				r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])


### PR DESCRIPTION
It uses the current capacity of the limiter as a hint as this is set
based on the maxParallelism field on the schema.