### PR TITLE
Reuse byte slices from relay handler

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2926,7 +2926,7 @@ func TestInput(t *testing.T) {
 	})
 }
 
-type inputArgumentsHello struct {}
+type inputArgumentsHello struct{}
 
 type inputArgumentsScalarMismatch1 struct{}
 
@@ -2946,7 +2946,7 @@ type helloInputMismatch struct {
 	World string
 }
 
-func (r *inputArgumentsHello) Hello(args struct { Input *helloInput }) string {
+func (r *inputArgumentsHello) Hello(args struct{ Input *helloInput }) string {
 	return "Hello " + args.Input.Name + "!"
 }
 
@@ -2954,7 +2954,7 @@ func (r *inputArgumentsScalarMismatch1) Hello(name string) string {
 	return "Hello " + name + "!"
 }
 
-func (r *inputArgumentsScalarMismatch2) Hello(args struct { World string }) string {
+func (r *inputArgumentsScalarMismatch2) Hello(args struct{ World string }) string {
 	return "Hello " + args.World + "!"
 }
 
@@ -2962,11 +2962,11 @@ func (r *inputArgumentsObjectMismatch1) Hello(in helloInput) string {
 	return "Hello " + in.Name + "!"
 }
 
-func (r *inputArgumentsObjectMismatch2) Hello(args struct { Input *helloInputMismatch }) string {
+func (r *inputArgumentsObjectMismatch2) Hello(args struct{ Input *helloInputMismatch }) string {
 	return "Hello " + args.Input.World + "!"
 }
 
-func (r *inputArgumentsObjectMismatch3) Hello(args struct { Input *struct { Thing string } }) string {
+func (r *inputArgumentsObjectMismatch3) Hello(args struct{ Input *struct{ Thing string } }) string {
 	return "Hello " + args.Input.Thing + "!"
 }
 

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -48,9 +48,9 @@ var BytePool = sync.Pool{
 
 func bufferUsingPool() *bytes.Buffer {
 	b := BytePool.Get().([]byte)
-	out := bytes.NewBuffer(b)
-	out.Reset()
-	return out
+	buf := bytes.NewBuffer(b)
+	buf.Reset()
+	return buf
 }
 
 func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *query.Operation) ([]byte, []*errors.QueryError) {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/graph-gophers/graphql-go/internal/exec"
 	"net/http"
 	"strings"
 
@@ -67,4 +68,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(responseJSON)
+
+	// Allow byte slice to be reused
+	exec.BytePool.Put(responseJSON)
 }


### PR DESCRIPTION
When using the relay handler the previous code would:

Create a empty byte buffer
Use it to build up the response (as raw json)
Return the raw bytes, converted to a json.RawMessage
Marshal the RawMessage which simply returns the bytes unhanged
Write the bytes to the a ResponseWriter
Throw away the bytes

The new code instead passes the final bytes back into a buffer pool so
that they can be reused when handling subsequent requests.